### PR TITLE
Add 1 to the value of Green Joker when calculating hand score

### DIFF
--- a/balatro-sim.js
+++ b/balatro-sim.js
@@ -492,7 +492,7 @@ class Hand {
         break;
       case 112:
         // Green Joker
-        this.mult = bigAdd(joker[VALUE], this.mult);
+        this.mult = bigAdd(1 + joker[VALUE], this.mult);
         break;
       case 115:
         // Cavendish

--- a/breakdown.js
+++ b/breakdown.js
@@ -614,8 +614,8 @@ class Hand {
         break;
       case 112:
         // Green Joker
-        this.mult = bigAdd(joker[VALUE], this.mult);
-        if(this.bd) this.breakdownPlusMult([joker], joker[VALUE]);
+        this.mult = bigAdd(1 + joker[VALUE], this.mult);
+        if(this.bd) this.breakdownPlusMult([joker], 1 + joker[VALUE]);
         break;
       case 115:
         // Cavendish


### PR DESCRIPTION
Similar to square joker, green joker's value increases on hand submission which is not currently taken into consideration by the calculator. [Green joker is already being incremented when you click the "play hand" button.](https://github.com/EFHIII/balatro-calculator/blob/main/main.js#L1020-L1023)