### PR TITLE
#96 Fix issue where the optimizer could return a non-optimal solution

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -179,29 +179,30 @@ function run(jokers = [[]]) {
                   bestCardsInHand = thisHand.cardsInHand;
                   originalHand = thisOriginalHand;
                 }
-                if(thisScore[1] < bestScore[1] || (thisScore[1] === bestScore[1] && thisScore[0] < bestScore[0]) || (bestCards.length === 0 && thisHand.cards.length > 0) || (thisScore[1] === bestScore[1] && thisScore[0] === bestScore[0] && sameScore > bestSameScore)) {
-                  bestScore = thisScore;
-                  bestHighScore = thisHand.simulateBestHand();
-                  bestSameScore = sameScore;
-                  bestCards = thisHand.cards;
-                  bestJokers = jokers[j];
-                  bestCardsInHand = thisHand.cardsInHand;
-                  originalHand = thisOriginalHand;
-                }
-                else if(thisScore[1] === bestScore[1] && thisScore[0] === bestScore[0] && sameScore === bestSameScore) {
-                  const bhs = thisHand.simulateBestHand();
-
-                  if(bhs < bestHighScore) {
+                if (thisHand.cards.length > 0 || bestHand.cards.length === 0) {
+                  if(thisScore[1] < bestScore[1] || (thisScore[1] === bestScore[1] && thisScore[0] < bestScore[0]) || (bestCards.length === 0 && thisHand.cards.length > 0) || (thisScore[1] === bestScore[1] && thisScore[0] === bestScore[0] && sameScore > bestSameScore)) {
                     bestScore = thisScore;
-                    bestHighScore = bhs;
+                    bestHighScore = thisHand.simulateBestHand();
                     bestSameScore = sameScore;
                     bestCards = thisHand.cards;
                     bestJokers = jokers[j];
                     bestCardsInHand = thisHand.cardsInHand;
                     originalHand = thisOriginalHand;
                   }
-                }
+                  else if(thisScore[1] === bestScore[1] && thisScore[0] === bestScore[0] && sameScore === bestSameScore) {
+                    const bhs = thisHand.simulateBestHand();
 
+                    if(bhs < bestHighScore) {
+                      bestScore = thisScore;
+                      bestHighScore = bhs;
+                      bestSameScore = sameScore;
+                      bestCards = thisHand.cards;
+                      bestJokers = jokers[j];
+                      bestCardsInHand = thisHand.cardsInHand;
+                      originalHand = thisOriginalHand;
+                    }
+                  }
+                }
               }
               else {
                 thisScore = thisHand.simulateWorstHand();
@@ -215,26 +216,28 @@ function run(jokers = [[]]) {
                   bestCardsInHand = thisHand.cardsInHand;
                   originalHand = thisOriginalHand;
                 }
-                if(thisScore[1] > bestScore[1] || (thisScore[1] === bestScore[1] && thisScore[0] > bestScore[0]) || (bestCards.length === 0 && thisHand.cards.length > 0) || (thisScore[1] === bestScore[1] && thisScore[0] === bestScore[0] && sameScore > bestSameScore)) {
-                  bestScore = thisScore;
-                  bestHighScore = thisHand.simulateBestHand();
-                  bestSameScore = sameScore;
-                  bestCards = thisHand.cards;
-                  bestJokers = jokers[j];
-                  bestCardsInHand = thisHand.cardsInHand;
-                  originalHand = thisOriginalHand;
-                }
-                else if(thisScore[1] === bestScore[1] && thisScore[0] === bestScore[0] && sameScore === bestSameScore) {
-                  const bhs = thisHand.simulateBestHand();
-
-                  if(bhs > bestHighScore) {
+                if (thisHand.cards.length > 0 || bestHand.cards.length === 0) {
+                  if(thisScore[1] > bestScore[1] || (thisScore[1] === bestScore[1] && thisScore[0] > bestScore[0]) || (bestCards.length === 0 && thisHand.cards.length > 0) || (thisScore[1] === bestScore[1] && thisScore[0] === bestScore[0] && sameScore > bestSameScore)) {
                     bestScore = thisScore;
-                    bestHighScore = bhs;
+                    bestHighScore = thisHand.simulateBestHand();
                     bestSameScore = sameScore;
                     bestCards = thisHand.cards;
                     bestJokers = jokers[j];
                     bestCardsInHand = thisHand.cardsInHand;
                     originalHand = thisOriginalHand;
+                  }
+                  else if(thisScore[1] === bestScore[1] && thisScore[0] === bestScore[0] && sameScore === bestSameScore) {
+                    const bhs = thisHand.simulateBestHand();
+
+                    if(bhs > bestHighScore) {
+                      bestScore = thisScore;
+                      bestHighScore = bhs;
+                      bestSameScore = sameScore;
+                      bestCards = thisHand.cards;
+                      bestJokers = jokers[j];
+                      bestCardsInHand = thisHand.cardsInHand;
+                      originalHand = thisOriginalHand;
+                    }
                   }
                 }
               }


### PR DESCRIPTION
**Refs**
this fixes https://github.com/EFHIII/balatro-calculator/issues/96

**Reproduction of this issue was dependent on the number of threads ( environment specific)**
I could only reproduce the issue on android. After some analysis thats because with the old logic the result of an optimizer run is dependent on the number of threads used, which was 7 for my android environment, but 12 for my desktop. This comes from the line const THREADS = navigator.hardwareConcurrency; in manageWorkers.js. Changing this for example to a hardcoded 7 allowed me to reproduce the issue on desktop as well.

**Root cause**
The issue lies in comparing scores for hands with size 0, the comparison is now non-transitive. Lets say there are 3 hands
 A with 1 card score 1
B with 0 cards score 3
 C with 1 card score 2

The logic to compare the scores considers B>A and A>B.
If the evaluation logic goes A -> B -> C then the resulting best hand will be C. However if it goes C -> B -> A then the resulting best hand is A. Depending on the number of threads the order in which the hands are compared changes, hence why the reproduction only happens on certain environments.

**Fix**
I decided to go with a relatively small fix. The only thing I did was a change to the logic where the 'best hand' is updated. I added that hands of size 0 can only be considered better if the current best hand also has size 0, so if the current best hand has  a non-zero size, then hands of size 0 are always considered worse.
Change is made both for minimize and maximize flows.

**Be aware of the confusion diff**
Unfortunately the diff is quite hard to read because git seems to have difficulties realizing what has been changed exactly. The only change made is the addition of two if statements ( lines 182 and 219) and then everything inside that block has been indented an additional level. 